### PR TITLE
Set precision to 1 if initialization produced an invalid value

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,16 +18,13 @@ Distributions = "0.25"
 GLM = "1"
 LogExpFunctions = "0.3"
 SpecialFunctions = "1, 2"
-StableRNGs = "1"
 StatsAPI = "1.5"
 StatsBase = "0.33, 0.34"
 StatsModels = "0.6, 0.7"
 julia = "1.6"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "StableRNGs", "Test"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,13 +18,16 @@ Distributions = "0.25"
 GLM = "1"
 LogExpFunctions = "0.3"
 SpecialFunctions = "1, 2"
+StableRNGs = "1"
 StatsAPI = "1.5"
 StatsBase = "0.33, 0.34"
 StatsModels = "0.6, 0.7"
 julia = "1.6"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "StableRNGs", "Test"]

--- a/src/BetaRegression.jl
+++ b/src/BetaRegression.jl
@@ -299,6 +299,9 @@ function initialize!(b::BetaRegressionModel)
         ϕ += μᵢ * (1 - μᵢ) / σᵢ² - 1
     end
     ϕ /= n
+    # No valid estimate for the precision, follow suit with `betareg` in R and set to 1
+    # See https://stats.stackexchange.com/a/593670
+    ϕ > 0 || (ϕ = one(ϕ))
     copyto!(params(b), push!(β, ϕ))
     copyto!(linearpredictor(b), η)
     return b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,6 @@
 using BetaRegression
-using Distributions
 using GLM
-using Random
 using StatsBase
-using StableRNGs
 using Test
 
 using GLM: linkinv
@@ -215,17 +212,13 @@ end
     end
 end
 
-@testset "pathological init" begin
-    invlogit(x) = inv(1 + exp(-x))
-    n = 100
-    X = ones(n, 1)
-    y = Vector{Float64}(undef, n)
-    # additional examples that get negative phi
-    # during fitting; originally in the loop below
-    # (0.2, 0.2), (0.5, 10), (10, 0.3)
-    for (α, β) in [(0.5, 0.5)]
-        y = rand!(StableRNG(42), Beta(α, β), y)
-        model = fit(BetaRegressionModel, X, y)
-        @test invlogit(first(coef(model))) ≈ mean(y) rtol=0.05
-    end
+@testset "Resetting an invalid initial precision" begin
+    X = ones(10, 1)
+    # Generated via `Beta(0.5, 0.5)`
+    y = [0.9020980693394288, 0.055577211500829754, 0.23132559790498958,
+         0.5813942170987118, 0.9709116084487788, 0.7754094004739907,
+         0.05982031817793439, 0.8670342033149658, 0.683216406088941,
+         0.141451701046685]
+    model = fit(BetaRegressionModel, X, y)
+    @test linkinv(Link(model), only(coef(model))) ≈ mean(y) rtol=0.05
 end


### PR DESCRIPTION
@jmmanley hit this in some internal code. I'm not sure offhand how to construct sufficiently pathological data such that this occurs, which is why I haven't yet added a test.