### PR TITLE
Constrain precision parameter during optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BetaRegression"
 uuid = "2339b9c3-daaf-4eaa-90d5-e8471159c344"
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
Also adjust some expressions for improved numerical accuracy.

The model coefficients are unbounded but the precision must be positive in order for the solution to be feasible. We can impose such a constraint by setting the precision to the maximum of the updated value at the current step and machine epsilon. This bumps Newton back into the feasible region so that optimization can continue in the right direction.

Based on ideas and discussion with Jason Manley and Phillip Alday. Both are included as coauthors of this commit.

Fixes #6.