### PR TITLE
fixed order of returns for inverselink(::Link01), and other compatibility fixes for GLM2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BetaRegression"
 uuid = "2339b9c3-daaf-4eaa-90d5-e8471159c344"
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -15,7 +15,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
 Distributions = "0.25"
-GLM = "1"
+GLM = ">=2"
 LinearAlgebra = "1"
 LogExpFunctions = "0.3"
 SpecialFunctions = "1, 2"

--- a/src/BetaRegression.jl
+++ b/src/BetaRegression.jl
@@ -408,7 +408,7 @@ function initialize!(b::BetaRegressionModel)
     # We have to use the constructors directly because `LinearModel` supports an
     # offset but it isn't exposed by `lm`
     model = LinearModel(LmResp{typeof(y)}(zero(y), offset(b), weights(b), y),
-                        cholpred(X, true))
+                        cholpred(X, true), nothing)
     fit!(model)
     β = coef(model)
     η = fitted(model)
@@ -450,7 +450,7 @@ function StatsAPI.score(b::BetaRegressionModel)
     Tr = copy(η)
     @inbounds for i in eachindex(y, η)
         yᵢ = y[i]
-        μᵢ, omμᵢ, dμdη = inverselink(link, η[i])
+        μᵢ, dμdη, omμᵢ = inverselink(link, η[i])
         ψp = digamma(ϕ * μᵢ)
         ψq = digamma(ϕ * omμᵢ)
         Δ = logit(yᵢ) - ψp + ψq   # logit(yᵢ) - 𝔼(logit(yᵢ))
@@ -496,7 +496,7 @@ function 🐟(b::BetaRegressionModel, expected::Bool, inverse::Bool)
     γ = zero(ϕ)
     for i in eachindex(y, η, w)
         ηᵢ = η[i]
-        μᵢ, omμᵢ, dμdη = inverselink(link, ηᵢ)
+        μᵢ, dμdη, omμᵢ = inverselink(link, ηᵢ)
         p = μᵢ * ϕ
         q = omμᵢ * ϕ
         ψ′p = trigamma(p)
@@ -701,7 +701,7 @@ dmueta(link::CauchitLink, η) = -2π * η * mueta(link, η)^2
 dmueta(link::CloglogLink, η) = -expm1(η) * mueta(link, η)
 
 function dmueta(link::LogitLink, η)
-    μ, _, dμdη = inverselink(link, η)
+    μ, dμdη, _ = inverselink(link, η)
     return dμdη * (1 - 2μ)
 end
 


### PR DESCRIPTION
see #11 

TODOs:

- [x] bump version number to `v0.2.0`
- [x] bump compat for GLM to `GLM >= 2`
- [ ] check if version bump is correct per `SemVer`
- [ ] compat needs work

Before testing `using Pkg; Pkg.develop("/path/to/dev/v2/GLM.jl/")` must be run